### PR TITLE
curve25519: fix loworder test after module updates

### DIFF
--- a/curve25519/curve25519_additional_test.v
+++ b/curve25519/curve25519_additional_test.v
@@ -348,17 +348,19 @@ mut:
 
 const smallloworderpk_zeroshared = [
 	SmallLowOrderPKZeros{
-		title:           '# public key = 0'
-		status:          '# acceptable: SmallPublicKey, LowOrderPublic, ZeroSharedSecret'
-		pvkey:           hex.decode('88227494038f2bb811d47805bcdf04a2ac585ada7f2f23389bfd4658f9ddd45e')!
+		title:  '# public key = 0'
+		status: '# acceptable: SmallPublicKey, LowOrderPublic, ZeroSharedSecret'
+		pvkey:  hex.decode('88227494038f2bb811d47805bcdf04a2ac585ada7f2f23389bfd4658f9ddd45e')!
+		// this zeros public key was early rejected on latest module updates
 		pbkey:           hex.decode('0000000000000000000000000000000000000000000000000000000000000000')!
 		expected_shared: hex.decode('0000000000000000000000000000000000000000000000000000000000000000')!
-		err:             error('bad input point: low order point')
+		err:             error('x25519: unallowed zeros/scalar point')
 	},
 	SmallLowOrderPKZeros{
-		title:           '# public key = 1'
-		status:          '# acceptable: SmallPublicKey, LowOrderPublic, ZeroSharedSecret'
-		pvkey:           hex.decode('48232e8972b61c7e61930eb9450b5070eae1c670475685541f0476217e48184f')!
+		title:  '# public key = 1'
+		status: '# acceptable: SmallPublicKey, LowOrderPublic, ZeroSharedSecret'
+		pvkey:  hex.decode('48232e8972b61c7e61930eb9450b5070eae1c670475685541f0476217e48184f')!
+		// TODO: should this ones be rejected ?
 		pbkey:           hex.decode('0100000000000000000000000000000000000000000000000000000000000000')!
 		expected_shared: hex.decode('0000000000000000000000000000000000000000000000000000000000000000')!
 		err:             error('bad input point: low order point')


### PR DESCRIPTION
This small fix of the `curve25519` additional test. The error on [24762 comment](https://github.com/vlang/v/pull/24762#issuecomment-2989906793) was happens after [24762](https://github.com/vlang/v/pull/24762) been merged where that PR add an early check for invalid zeros bytes of scalar (point)
before enter scalar multiplication routines.

The error message need to be updated according to the new one.